### PR TITLE
Add frontend demo for patent monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # patent
 
-This repository provides sample frontend pages demonstrating a patent for edge-computing based power load monitoring. The `frontend` folder contains a Bootstrap-based web UI with Chinese localization.
+This repository provides sample frontend pages demonstrating a patent for edge-computing based power load monitoring. The `frontend` folder contains a Bootstrap-based web UI in Chinese.
+
+### Pages
+
+- **登录**：用户登录入口。
+- **实时监控**：显示实时负荷曲线。
+- **负荷趋势**：浏览历史数据趋势。
+- **事件概览**：查看最近的关键事件。
+- **节点管理**：展示各边缘节点状态。
+- **系统设置**：调整刷新间隔与主题。
 
 ## Running
-Open the `frontend/index.html` page in your browser to start. Fonts are loaded from Google Fonts (Noto Sans SC) to ensure proper Chinese display. After login you will be redirected to the monitor page.
+Open `frontend/index.html` in your browser to start. Fonts are loaded from Google Fonts (Noto Sans SC) to ensure proper Chinese display. After login you will be redirected to the monitor page.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # patent
-专利审查材料
+
+This repository provides sample frontend pages demonstrating a patent for edge-computing based power load monitoring. The `frontend` folder contains a simple Bootstrap-based web UI.
+
+## Running
+Open any of the HTML pages inside `frontend/` in your browser (e.g., `frontend/index.html`). The sign-in page will redirect you to the Real-Time Monitor upon login.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # patent
 
-This repository provides sample frontend pages demonstrating a patent for edge-computing based power load monitoring. The `frontend` folder contains a simple Bootstrap-based web UI.
+This repository provides sample frontend pages demonstrating a patent for edge-computing based power load monitoring. The `frontend` folder contains a Bootstrap-based web UI with Chinese localization.
 
 ## Running
-Open any of the HTML pages inside `frontend/` in your browser (e.g., `frontend/index.html`). The sign-in page will redirect you to the Real-Time Monitor upon login.
+Open the `frontend/index.html` page in your browser to start. Fonts are loaded from Google Fonts (Noto Sans SC) to ensure proper Chinese display. After login you will be redirected to the monitor page.

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,0 +1,10 @@
+body {
+  padding-top: 70px;
+}
+.navbar-brand {
+  font-weight: bold;
+}
+.table-wrap {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC&display=swap');
 body {
   padding-top: 70px;
+  font-family: 'Noto Sans SC', 'Microsoft YaHei', sans-serif;
 }
 .navbar-brand {
   font-weight: bold;

--- a/frontend/events.html
+++ b/frontend/events.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="负荷事件列表">
   <title>事件概览</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,13 +37,13 @@
       <thead>
         <tr><th>时间</th><th>电压</th><th>电流</th><th>功率</th></tr>
       </thead>
-      <tbody id="eventBody"></tbody>
+      <tbody id="eventBody" aria-live="polite"></tbody>
     </table>
   </div>
 </div>
 
-<script src="js/main.js"></script>
-<script src="js/events.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="js/main.js"></script>
+<script defer src="js/events.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/frontend/events.html
+++ b/frontend/events.html
@@ -1,38 +1,40 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Event Summary</title>
+  <title>事件概览</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <a class="navbar-brand" href="monitor.html">监控中心</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExample">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
-        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
-        <li class="nav-item"><a class="nav-link active" href="events.html">Event Summary</a></li>
-        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
-        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+        <li class="nav-item"><a class="nav-link" href="monitor.html">实时监控</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">负荷趋势</a></li>
+        <li class="nav-item"><a class="nav-link active" href="events.html">事件概览</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">节点管理</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">系统设置</a></li>
       </ul>
-      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+      <button class="btn btn-outline-light" id="logoutBtn">退出</button>
     </div>
   </div>
 </nav>
 
 <div class="container">
-  <h3>Recent Events</h3>
+  <h3>最近事件</h3>
   <div class="table-wrap">
     <table class="table table-striped">
       <thead>
-        <tr><th>Time</th><th>Voltage</th><th>Current</th><th>Power</th></tr>
+        <tr><th>时间</th><th>电压</th><th>电流</th><th>功率</th></tr>
       </thead>
       <tbody id="eventBody"></tbody>
     </table>

--- a/frontend/events.html
+++ b/frontend/events.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Event Summary</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
+        <li class="nav-item"><a class="nav-link active" href="events.html">Event Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+    </div>
+  </div>
+</nav>
+
+<div class="container">
+  <h3>Recent Events</h3>
+  <div class="table-wrap">
+    <table class="table table-striped">
+      <thead>
+        <tr><th>Time</th><th>Voltage</th><th>Current</th><th>Power</th></tr>
+      </thead>
+      <tbody id="eventBody"></tbody>
+    </table>
+  </div>
+</div>
+
+<script src="js/main.js"></script>
+<script src="js/events.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,7 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="负荷监控系统">
   <meta http-equiv="refresh" content="0; url=signin.html" />
 </head>
-<body></body>
+<body>
+  <noscript>
+    <p>如果浏览器没有自动跳转，请<a href="signin.html">点击这里登录</a>。</p>
+  </noscript>
+</body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta http-equiv="refresh" content="0; url=signin.html" />
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url=signin.html" />
+</head>
+<body></body>
+</html>

--- a/frontend/js/events.js
+++ b/frontend/js/events.js
@@ -1,0 +1,17 @@
+checkLogin();
+function loadEvents() {
+  const tbody = document.getElementById('eventBody');
+  tbody.innerHTML = '';
+  for (let i = 0; i < 10; i++) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${new Date().toLocaleString()}</td>
+      <td>${(Math.random()*100+300).toFixed(2)}</td>
+      <td>${(Math.random()*50).toFixed(2)}</td>
+      <td>${(Math.random()*5).toFixed(2)}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadEvents);

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -1,0 +1,16 @@
+function handleLogin(evt) {
+  evt.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value.trim();
+  if (username && password) {
+    localStorage.setItem('loggedIn', 'true');
+    window.location.href = 'monitor.html';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('loginForm');
+  if (form) {
+    form.addEventListener('submit', handleLogin);
+  }
+});

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,0 +1,17 @@
+function checkLogin() {
+  if (!localStorage.getItem('loggedIn')) {
+    window.location.href = 'signin.html';
+  }
+}
+
+function logout() {
+  localStorage.removeItem('loggedIn');
+  window.location.href = 'signin.html';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const logoutBtn = document.getElementById('logoutBtn');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', logout);
+  }
+});

--- a/frontend/js/monitor.js
+++ b/frontend/js/monitor.js
@@ -7,7 +7,7 @@ function initChart() {
     data: {
       labels: [],
       datasets: [{
-        label: 'Power (kW)',
+        label: '功率(kW)',
         data: [],
         borderColor: 'rgba(75,192,192,1)',
         fill: false

--- a/frontend/js/monitor.js
+++ b/frontend/js/monitor.js
@@ -1,0 +1,40 @@
+checkLogin();
+let chart;
+function initChart() {
+  const ctx = document.getElementById('realtimeChart');
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [{
+        label: 'Power (kW)',
+        data: [],
+        borderColor: 'rgba(75,192,192,1)',
+        fill: false
+      }]
+    },
+    options: {
+      scales: {
+        x: {display: true},
+        y: {beginAtZero: true}
+      }
+    }
+  });
+}
+
+function addData() {
+  const now = new Date().toLocaleTimeString();
+  const value = Math.random() * 100 + 300;
+  chart.data.labels.push(now);
+  chart.data.datasets[0].data.push(value.toFixed(2));
+  if (chart.data.labels.length > 20) {
+    chart.data.labels.shift();
+    chart.data.datasets[0].data.shift();
+  }
+  chart.update();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initChart();
+  setInterval(addData, 1000);
+});

--- a/frontend/js/nodes.js
+++ b/frontend/js/nodes.js
@@ -5,8 +5,8 @@ function loadNodes() {
   for (let i=1;i<=5;i++) {
     const tr = document.createElement('tr');
     tr.innerHTML=`
-      <td>Node-${i}</td>
-      <td>${Math.random()>0.2?'Online':'Offline'}</td>
+      <td>节点-${i}</td>
+      <td>${Math.random()>0.2?'在线':'离线'}</td>
       <td>${(Math.random()*50+10).toFixed(1)} kbps</td>
     `;
     tbody.appendChild(tr);

--- a/frontend/js/nodes.js
+++ b/frontend/js/nodes.js
@@ -1,0 +1,16 @@
+checkLogin();
+function loadNodes() {
+  const tbody = document.getElementById('nodeBody');
+  tbody.innerHTML='';
+  for (let i=1;i<=5;i++) {
+    const tr = document.createElement('tr');
+    tr.innerHTML=`
+      <td>Node-${i}</td>
+      <td>${Math.random()>0.2?'Online':'Offline'}</td>
+      <td>${(Math.random()*50+10).toFixed(1)} kbps</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadNodes);

--- a/frontend/js/preferences.js
+++ b/frontend/js/preferences.js
@@ -1,0 +1,19 @@
+checkLogin();
+function savePreferences(evt) {
+  evt.preventDefault();
+  const interval = document.getElementById('refreshInterval').value;
+  const theme = document.getElementById('themeSelect').value;
+  localStorage.setItem('refreshInterval', interval);
+  localStorage.setItem('theme', theme);
+  alert('Preferences saved');
+}
+
+function loadPreferences() {
+  document.getElementById('refreshInterval').value = localStorage.getItem('refreshInterval') || 1000;
+  document.getElementById('themeSelect').value = localStorage.getItem('theme') || 'light';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadPreferences();
+  document.getElementById('prefForm').addEventListener('submit', savePreferences);
+});

--- a/frontend/js/trend.js
+++ b/frontend/js/trend.js
@@ -8,7 +8,7 @@ function initTrendChart() {
     data: {
       labels: [],
       datasets: [{
-        label: 'Historical Load',
+        label: '历史负荷',
         data: [],
         borderColor: '#ff6384',
         fill: false

--- a/frontend/js/trend.js
+++ b/frontend/js/trend.js
@@ -1,0 +1,31 @@
+checkLogin();
+let trendChart;
+
+function initTrendChart() {
+  const ctx = document.getElementById('trendChart');
+  trendChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [{
+        label: 'Historical Load',
+        data: [],
+        borderColor: '#ff6384',
+        fill: false
+      }]
+    }
+  });
+  loadDummyData();
+}
+
+function loadDummyData() {
+  const now = new Date();
+  for (let i = 0; i < 30; i++) {
+    const date = new Date(now.getTime() - i * 3600000);
+    trendChart.data.labels.unshift(date.toLocaleString());
+    trendChart.data.datasets[0].data.unshift((Math.random() * 100 + 300).toFixed(2));
+  }
+  trendChart.update();
+}
+
+document.addEventListener('DOMContentLoaded', initTrendChart);

--- a/frontend/monitor.html
+++ b/frontend/monitor.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Real-Time Monitor</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link active" href="monitor.html">Real-Time Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+    </div>
+  </div>
+</nav>
+
+<div class="container">
+  <h3>Real-Time Load</h3>
+  <canvas id="realtimeChart" height="100"></canvas>
+</div>
+
+<script src="js/main.js"></script>
+<script src="js/monitor.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/monitor.html
+++ b/frontend/monitor.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="实时电表负荷监控">
   <title>实时监控</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -32,11 +33,11 @@
 
 <div class="container">
   <h3>实时负荷</h3>
-  <canvas id="realtimeChart" height="100"></canvas>
+  <canvas id="realtimeChart" height="100" aria-label="实时负荷曲线" role="img"></canvas>
 </div>
 
-<script src="js/main.js"></script>
-<script src="js/monitor.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="js/main.js"></script>
+<script defer src="js/monitor.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/frontend/monitor.html
+++ b/frontend/monitor.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Real-Time Monitor</title>
+  <title>实时监控</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -11,25 +13,25 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <a class="navbar-brand" href="monitor.html">监控中心</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExample">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link active" href="monitor.html">Real-Time Monitor</a></li>
-        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
-        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
-        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
-        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+        <li class="nav-item"><a class="nav-link active" href="monitor.html">实时监控</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">负荷趋势</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">事件概览</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">节点管理</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">系统设置</a></li>
       </ul>
-      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+      <button class="btn btn-outline-light" id="logoutBtn">退出</button>
     </div>
   </div>
 </nav>
 
 <div class="container">
-  <h3>Real-Time Load</h3>
+  <h3>实时负荷</h3>
   <canvas id="realtimeChart" height="100"></canvas>
 </div>
 

--- a/frontend/nodes.html
+++ b/frontend/nodes.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Node Control</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
+        <li class="nav-item"><a class="nav-link active" href="nodes.html">Node Control</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+    </div>
+  </div>
+</nav>
+
+<div class="container">
+  <h3>Nodes</h3>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th>Node</th><th>Status</th><th>Upload Rate</th></tr>
+    </thead>
+    <tbody id="nodeBody"></tbody>
+  </table>
+</div>
+
+<script src="js/main.js"></script>
+<script src="js/nodes.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/nodes.html
+++ b/frontend/nodes.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="边缘节点状态监控">
   <title>节点管理</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -35,12 +36,12 @@
     <thead>
       <tr><th>节点</th><th>状态</th><th>上传速率</th></tr>
     </thead>
-    <tbody id="nodeBody"></tbody>
+    <tbody id="nodeBody" aria-live="polite"></tbody>
   </table>
 </div>
 
-<script src="js/main.js"></script>
-<script src="js/nodes.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="js/main.js"></script>
+<script defer src="js/nodes.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/frontend/nodes.html
+++ b/frontend/nodes.html
@@ -1,37 +1,39 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Node Control</title>
+  <title>节点管理</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <a class="navbar-brand" href="monitor.html">监控中心</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExample">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
-        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
-        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
-        <li class="nav-item"><a class="nav-link active" href="nodes.html">Node Control</a></li>
-        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+        <li class="nav-item"><a class="nav-link" href="monitor.html">实时监控</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">负荷趋势</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">事件概览</a></li>
+        <li class="nav-item"><a class="nav-link active" href="nodes.html">节点管理</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">系统设置</a></li>
       </ul>
-      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+      <button class="btn btn-outline-light" id="logoutBtn">退出</button>
     </div>
   </div>
 </nav>
 
 <div class="container">
-  <h3>Nodes</h3>
+  <h3>节点列表</h3>
   <table class="table table-bordered">
     <thead>
-      <tr><th>Node</th><th>Status</th><th>Upload Rate</th></tr>
+      <tr><th>节点</th><th>状态</th><th>上传速率</th></tr>
     </thead>
     <tbody id="nodeBody"></tbody>
   </table>

--- a/frontend/preferences.html
+++ b/frontend/preferences.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="系统参数设置">
   <title>系统设置</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -47,8 +48,8 @@
   </form>
 </div>
 
-<script src="js/main.js"></script>
-<script src="js/preferences.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="js/main.js"></script>
+<script defer src="js/preferences.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/frontend/preferences.html
+++ b/frontend/preferences.html
@@ -1,47 +1,49 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Preferences</title>
+  <title>系统设置</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <a class="navbar-brand" href="monitor.html">监控中心</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExample">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
-        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
-        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
-        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
-        <li class="nav-item"><a class="nav-link active" href="preferences.html">Preferences</a></li>
+        <li class="nav-item"><a class="nav-link" href="monitor.html">实时监控</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">负荷趋势</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">事件概览</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">节点管理</a></li>
+        <li class="nav-item"><a class="nav-link active" href="preferences.html">系统设置</a></li>
       </ul>
-      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+      <button class="btn btn-outline-light" id="logoutBtn">退出</button>
     </div>
   </div>
 </nav>
 
 <div class="container">
-  <h3>Preferences</h3>
+  <h3>系统设置</h3>
   <form id="prefForm" class="mt-3">
     <div class="mb-3">
-      <label for="refreshInterval" class="form-label">Refresh Interval (ms)</label>
+      <label for="refreshInterval" class="form-label">刷新间隔(ms)</label>
       <input type="number" class="form-control" id="refreshInterval" required>
     </div>
     <div class="mb-3">
-      <label for="themeSelect" class="form-label">Theme</label>
+      <label for="themeSelect" class="form-label">主题</label>
       <select class="form-select" id="themeSelect">
-        <option value="light">Light</option>
-        <option value="dark">Dark</option>
+        <option value="light">明亮</option>
+        <option value="dark">黑暗</option>
       </select>
     </div>
-    <button type="submit" class="btn btn-primary">Save</button>
+    <button type="submit" class="btn btn-primary">保存</button>
   </form>
 </div>
 

--- a/frontend/preferences.html
+++ b/frontend/preferences.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Preferences</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="trend.html">Trend Explorer</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
+        <li class="nav-item"><a class="nav-link active" href="preferences.html">Preferences</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+    </div>
+  </div>
+</nav>
+
+<div class="container">
+  <h3>Preferences</h3>
+  <form id="prefForm" class="mt-3">
+    <div class="mb-3">
+      <label for="refreshInterval" class="form-label">Refresh Interval (ms)</label>
+      <input type="number" class="form-control" id="refreshInterval" required>
+    </div>
+    <div class="mb-3">
+      <label for="themeSelect" class="form-label">Theme</label>
+      <select class="form-select" id="themeSelect">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+
+<script src="js/main.js"></script>
+<script src="js/preferences.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign In</title>
+  <title>登录</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="css/style.css" rel="stylesheet">
 </head>
@@ -11,17 +13,17 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-4">
-        <h2 class="text-center mt-5 mb-4">Sign In</h2>
+        <h2 class="text-center mt-5 mb-4">用户登录</h2>
         <form id="loginForm">
           <div class="mb-3">
-            <label for="username" class="form-label">Username</label>
+            <label for="username" class="form-label">用户名</label>
             <input type="text" class="form-control" id="username" required>
           </div>
           <div class="mb-3">
-            <label for="password" class="form-label">Password</label>
+            <label for="password" class="form-label">密码</label>
             <input type="password" class="form-control" id="password" required>
           </div>
-          <button type="submit" class="btn btn-primary w-100">Login</button>
+          <button type="submit" class="btn btn-primary w-100">登录</button>
         </form>
       </div>
     </div>

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign In</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="css/style.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-4">
+        <h2 class="text-center mt-5 mb-4">Sign In</h2>
+        <form id="loginForm">
+          <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" required>
+          </div>
+          <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Login</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <script src="js/login.js"></script>
+</body>
+</html>

--- a/frontend/signin.html
+++ b/frontend/signin.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="边缘计算负荷监测登录">
   <title>登录</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -28,6 +29,7 @@
       </div>
     </div>
   </div>
-  <script src="js/login.js"></script>
+  <script defer src="js/login.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/frontend/trend.html
+++ b/frontend/trend.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Trend Explorer</title>
+  <title>负荷趋势</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -11,25 +13,25 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <a class="navbar-brand" href="monitor.html">监控中心</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExample">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
-        <li class="nav-item"><a class="nav-link active" href="trend.html">Trend Explorer</a></li>
-        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
-        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
-        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+        <li class="nav-item"><a class="nav-link" href="monitor.html">实时监控</a></li>
+        <li class="nav-item"><a class="nav-link active" href="trend.html">负荷趋势</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">事件概览</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">节点管理</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">系统设置</a></li>
       </ul>
-      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+      <button class="btn btn-outline-light" id="logoutBtn">退出</button>
     </div>
   </div>
 </nav>
 
 <div class="container">
-  <h3>Load Trend</h3>
+  <h3>负荷趋势</h3>
   <canvas id="trendChart" height="100"></canvas>
 </div>
 

--- a/frontend/trend.html
+++ b/frontend/trend.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trend Explorer</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="monitor.html">Monitor</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample" aria-controls="navbarsExample" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarsExample">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="monitor.html">Real-Time Monitor</a></li>
+        <li class="nav-item"><a class="nav-link active" href="trend.html">Trend Explorer</a></li>
+        <li class="nav-item"><a class="nav-link" href="events.html">Event Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="nodes.html">Node Control</a></li>
+        <li class="nav-item"><a class="nav-link" href="preferences.html">Preferences</a></li>
+      </ul>
+      <button class="btn btn-outline-light" id="logoutBtn">Logout</button>
+    </div>
+  </div>
+</nav>
+
+<div class="container">
+  <h3>Load Trend</h3>
+  <canvas id="trendChart" height="100"></canvas>
+</div>
+
+<script src="js/main.js"></script>
+<script src="js/trend.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/trend.html
+++ b/frontend/trend.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="历史负荷趋势分析">
   <title>负荷趋势</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -32,11 +33,11 @@
 
 <div class="container">
   <h3>负荷趋势</h3>
-  <canvas id="trendChart" height="100"></canvas>
+  <canvas id="trendChart" height="100" aria-label="负荷趋势图" role="img"></canvas>
 </div>
 
-<script src="js/main.js"></script>
-<script src="js/trend.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="js/main.js"></script>
+<script defer src="js/trend.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement Bootstrap-based frontend in `frontend/`
- add navigation and sample pages (monitor, trend, events, nodes, preferences, signin)
- add simple JS modules for login, charts, and dummy data
- update README with running instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1f6256f083258c54235e48d58de4